### PR TITLE
Use CPython 3.12.2

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,6 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, mkdir, AutoPackager, update_conandata
 from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
 from conan.tools.scm import Version
-from jinja2 import Template
 
 
 required_conan_version = ">=1.58.0 <2.0.0"
@@ -103,8 +102,8 @@ class DulcificumConan(ConanFile):
         if self.options.with_apps:
             self.requires("docopt.cpp/0.6.3")
         if self.options.with_python_bindings:
-            self.requires("cpython/3.10.4@ultimaker/stable")
-            self.requires("pybind11/2.10.4")
+            self.requires("cpython/3.12.2@ultimaker/cura_11079")
+            self.requires("pybind11/2.11.1")
 
     def build_requirements(self):
         self.test_requires("standardprojectsettings/[>=0.1.0]@ultimaker/stable")
@@ -136,13 +135,15 @@ class DulcificumConan(ConanFile):
 
         tc.variables["WITH_PYTHON_BINDINGS"] = self.options.with_python_bindings
         if self.options.with_python_bindings:
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0148"] = "OLD"
             tc.variables["PYTHON_EXECUTABLE"] = self.deps_user_info["cpython"].python.replace("\\", "/")
             tc.variables["Python_USE_STATIC_LIBS"] = not self.options["cpython"].shared
-            tc.variables["Python_ROOT_DIR"] = self.deps_cpp_info["cpython"].rootpath.replace("\\", "/")
+            tc.variables["Python_ROOT_DIR"] = self.deps_user_info["cpython"].pythonhome.replace("\\", "/")
             tc.variables["Python_FIND_FRAMEWORK"] = "NEVER"
             tc.variables["Python_FIND_REGISTRY"] = "NEVER"
             tc.variables["Python_FIND_IMPLEMENTATIONS"] = "CPython"
             tc.variables["Python_FIND_STRATEGY"] = "LOCATION"
+
             tc.variables["PYDULCIFICUM_VERSION"] = self.version
 
         if is_msvc(self):

--- a/pyDulcificum/CMakeLists.txt
+++ b/pyDulcificum/CMakeLists.txt
@@ -1,8 +1,9 @@
-    find_package(pybind11 REQUIRED)
+set(ENV{LD_LIBRARY_PATH} "${CMAKE_LIBRARY_PATH}:${LD_LIBRARY_PATH}")  # Needed to ensure that CMake finds the Conan CPython library
+find_package(pybind11 REQUIRED)
 
-    pybind11_add_module(pyDulcificum pyDulcificum.cpp)
-    target_link_libraries(pyDulcificum PUBLIC dulcificum pybind11::pybind11)
-    target_compile_definitions(pyDulcificum PRIVATE PYDULCIFICUM_VERSION="${PYDULCIFICUM_VERSION}")
-    if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
-        pybind11_strip(pyDulcificum)
-    endif()
+pybind11_add_module(pyDulcificum pyDulcificum.cpp)
+target_link_libraries(pyDulcificum PUBLIC dulcificum pybind11::pybind11)
+target_compile_definitions(pyDulcificum PRIVATE PYDULCIFICUM_VERSION="${PYDULCIFICUM_VERSION}")
+if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+    pybind11_strip(pyDulcificum)
+endif()


### PR DESCRIPTION
This commit updates the Python bindings to use cpython/3.12.2 and pybind11/2.11.1. Additionally, a modification has been made to the CMake list to ensure the Conan CPython library is found, by setting the 'LD_LIBRARY_PATH' environment variable. Other minor changes have been made to the 'conanfile.py' to correct the 'Python_ROOT_DIR' variable, along with the removal of an unused import.

Contribute to CURA-11079