### PR TITLE
Allow M106 command to not specify P parameter

### DIFF
--- a/src/gcode/ast/entries.cpp
+++ b/src/gcode/ast/entries.cpp
@@ -164,7 +164,7 @@ M106::M106(size_t line_index, const std::string& raw_line, regex_result_t captur
     if (const auto& value = captured.get<"S">()) { S = utils::stringConvert<double>(value.to_view()); }
     if (const auto& value = captured.get<"P">()) { P = utils::stringConvert<size_t>(value.to_view()); }
     // clang-format on
-    if (S == std::nullopt && P == std::nullopt)
+    if (S == std::nullopt)
     {
         throw std::runtime_error(fmt::format("Unable to parse: [{}] {}", line_index, raw_line));
     }


### PR DESCRIPTION
M106 command's P parameter is actually optional and defaults to 0 when not specified. Unitl now we would always specify it, but now we do use it without specifying the P when the index is 0.

Contributes to CURA-11795