### PR TITLE
Bump version for Cura 5.8

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: "0.2.0-alpha.0"
+version: "0.2.1"


### PR DESCRIPTION
A change was made since 5.7 so we need to change the version.
Also dropping the "beta" because this seems to be stable. The major "0" is a still a reminder that this is quite experimental work.