### PR TITLE
Remove redundant fPIC check and improve pybind11 config

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -81,8 +81,6 @@ class DulcificumConan(ConanFile):
             del self.options.with_python_bindings
 
     def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
         if self.options.get_safe("with_python_bindings", False):
             self.options["cpython"].shared = True
 

--- a/pyDulcificum/CMakeLists.txt
+++ b/pyDulcificum/CMakeLists.txt
@@ -1,8 +1,10 @@
-    find_package(pybind11 REQUIRED)
+set(ENV{LD_LIBRARY_PATH} "${CMAKE_LIBRARY_PATH}:${LD_LIBRARY_PATH}")  # Needed to ensure that CMake finds the Conan CPython library
+find_package(Python COMPONENTS Interpreter Development)
+find_package(pybind11 REQUIRED)
 
-    pybind11_add_module(pyDulcificum pyDulcificum.cpp)
-    target_link_libraries(pyDulcificum PUBLIC dulcificum pybind11::pybind11)
-    target_compile_definitions(pyDulcificum PRIVATE PYDULCIFICUM_VERSION="${PYDULCIFICUM_VERSION}")
-    if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
-        pybind11_strip(pyDulcificum)
-    endif()
+pybind11_add_module(pyDulcificum pyDulcificum.cpp)
+target_link_libraries(pyDulcificum PUBLIC dulcificum pybind11::pybind11)
+target_compile_definitions(pyDulcificum PRIVATE PYDULCIFICUM_VERSION="${PYDULCIFICUM_VERSION}")
+if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+    pybind11_strip(pyDulcificum)
+endif()


### PR DESCRIPTION
This commit removes the redundant fPIC option check for shared builds in the `conanfile.py`. Additionally, it improves the `CMakeLists.txt` for `pyDulcificum` to correctly find the Python components required for building and linking the module, ensuring compatibility and correct linking with the Conan CPython library.