### PR TITLE
CURA-12313 Add argument to set actual number of output extruders

### DIFF
--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'include/**'
       - 'src/**'
-      - 'test/**'
+      - 'tests/**'
       - 'test_package/**'
       - 'conanfile.py'
       - 'CMakeLists.txt'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(DULCIFICUM_SRC
         src/gcode/parse.cpp
         src/miracle_jtp/mgjtp_command_to_json.cpp
         src/miracle_jtp/mgjtp_json_to_command.cpp
+        src/miracle_jtp/mgjtp_mappings_json_key_to_str.cpp
         src/gcode/gcode_to_command.cpp
         src/utils/io.cpp
         src/command_types.cpp

--- a/apps/cmdline.h
+++ b/apps/cmdline.h
@@ -20,7 +20,7 @@ constexpr std::string_view USAGE = R"({0}.
 Dulcificum changes the flavor, or dialect, of 3d printer commands
 
 Usage:
-  translator [--quiet | --verbose] --input=FLAVOR INPUT --output=FLAVOR OUTPUT
+  translator [--quiet | --verbose] --input=FLAVOR INPUT --output=FLAVOR OUTPUT [--nb_extruders=X]
   translator (-h | --help)
   translator --version
 
@@ -31,6 +31,7 @@ Options:
   --verbose                      Output more log statements
   --input=TYPE                   'miracle_jtp' | 'griffin'
   --output=FLAVOR                'miracle_jtp' | 'griffin'
+  --nb_extruders=X               Number of output extruders (default 2)
 )";
 
 } // namespace apps::cmdline

--- a/apps/translator_main.cpp
+++ b/apps/translator_main.cpp
@@ -28,7 +28,14 @@ int main(int argc, const char** argv)
     }
     spdlog::info("Tasting the menu");
 
+    size_t nb_extruders = 2;
+    auto nb_extruders_arg = args.at("--nb_extruders");
+    if(nb_extruders_arg)
+    {
+        nb_extruders = nb_extruders_arg.asLong();
+    }
+
     auto input{ dulcificum::utils::readFile(args.at("INPUT").asString()).value() };
-    auto translated = dulcificum::GCode2Miracle_JTP(input);
+    auto translated = dulcificum::GCode2Miracle_JTP(input, nb_extruders);
     dulcificum::utils::writeFile(args.at("OUTPUT").asString(), translated);
 }

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,2 +1,2 @@
-version: "0.2.1"
+version: "0.3.0"
 commit_hash: "unknown"

--- a/include/dulcificum.h
+++ b/include/dulcificum.h
@@ -3,20 +3,23 @@
 
 #include <nlohmann/json_fwd.hpp>
 #ifndef DULCIFICUM_VERSION
-#define DULCIFICUM_VERSION "0.2.1"
+#define DULCIFICUM_VERSION "0.3.0"
 #endif
 
 #include "dulcificum/gcode/gcode_to_command.h"
 #include "dulcificum/gcode/parse.h"
 #include "dulcificum/miracle_jtp/mgjtp_command_to_json.h"
+#include "dulcificum/miracle_jtp/mgjtp_mappings_json_key_to_str.h"
 #include "range/v3/view/enumerate.hpp"
 #include "sstream"
 
 namespace dulcificum
 {
 
-[[nodiscard]] std::string GCode2Miracle_JTP(const std::string& content)
+[[nodiscard]] std::string GCode2Miracle_JTP(const std::string& content, const size_t nb_extruders = 2)
 {
+    miracle_jtp::k_key_str::init(nb_extruders);
+
     auto gcode_ast = dulcificum::gcode::parse(content);
     auto command_list = dulcificum::gcode::toCommand(gcode_ast);
     std::stringstream stream;

--- a/include/dulcificum/miracle_jtp/mgjtp_mappings_json_key_to_str.h
+++ b/include/dulcificum/miracle_jtp/mgjtp_mappings_json_key_to_str.h
@@ -62,7 +62,9 @@ constexpr static std::string_view value{ "value" };
 constexpr static std::string_view x{ "x" };
 constexpr static std::string_view y{ "y" };
 constexpr static std::string_view z{ "z" };
-constexpr static std::array<const std::string_view, 5> k_param_point_names{ x, y, z, a, b };
+extern std::vector<std::string_view> k_param_point_names;
+
+extern void init(const size_t nb_extruders);
 
 } // namespace miracle_jtp::k_key_str
 

--- a/pyDulcificum/pyDulcificum.cpp
+++ b/pyDulcificum/pyDulcificum.cpp
@@ -43,5 +43,5 @@ PYBIND11_MODULE(pyDulcificum, module)
         py::arg("content"),
         "Writes a given string to a file.");
 
-    module.def("gcode_2_miracle_jtp", &dulcificum::GCode2Miracle_JTP, "Converts GGode to Miracle JSON Toolpaths", py::arg("content"));
+    module.def("gcode_2_miracle_jtp", &dulcificum::GCode2Miracle_JTP, "Converts GGode to Miracle JSON Toolpaths", py::arg("content"), py::arg("nb_extruders") = 2);
 }

--- a/src/miracle_jtp/mgjtp_mappings_json_key_to_str.cpp
+++ b/src/miracle_jtp/mgjtp_mappings_json_key_to_str.cpp
@@ -1,0 +1,35 @@
+#include "dulcificum/miracle_jtp/mgjtp_mappings_json_key_to_str.h"
+
+#include <spdlog/spdlog.h>
+
+namespace dulcificum::miracle_jtp
+{
+
+namespace k_key_str
+{
+
+std::vector<std::string_view> k_param_point_names = {};
+
+void init(const size_t nb_extruders)
+{
+    spdlog::info("Initializing with {} extruder(s)", nb_extruders);
+
+    k_param_point_names = { x, y, z };
+
+    if (nb_extruders >= 1)
+    {
+        k_param_point_names.push_back(a);
+    }
+    if (nb_extruders >= 2)
+    {
+        k_param_point_names.push_back(b);
+    }
+    if (nb_extruders >= 3)
+    {
+        spdlog::error("Using more than 2 extruders is not supported, using 2 instead");
+    }
+}
+
+} // namespace k_key_str
+
+} // namespace dulcificum::miracle_jtp

--- a/tests/miracle_jsontoolpath_dialect_test.cpp
+++ b/tests/miracle_jsontoolpath_dialect_test.cpp
@@ -7,7 +7,18 @@
 
 using namespace dulcificum;
 
-TEST(miracle_jtp_tests, move)
+class MiracleJTP : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        miracle_jtp::k_key_str::init(2);
+    }
+
+    void TearDown() override { }
+};
+
+TEST_F(MiracleJTP, move)
 {
     botcmd::Move move;
     move.feedrate = 0.4242;
@@ -19,7 +30,7 @@ TEST(miracle_jtp_tests, move)
     EXPECT_EQ(jmove, jmove1);
 }
 
-TEST(miracle_jtp_tests, change_toolhead)
+TEST_F(MiracleJTP, change_toolhead)
 {
     botcmd::ChangeTool cmd;
     cmd.position[0] = -4.2;
@@ -31,7 +42,7 @@ TEST(miracle_jtp_tests, change_toolhead)
     EXPECT_EQ(jcmd, jcmd1);
 }
 
-TEST(miracle_jtp_tests, fan_duty)
+TEST_F(MiracleJTP, fan_duty)
 {
     botcmd::FanDuty cmd;
     cmd.index = 0;
@@ -44,7 +55,7 @@ TEST(miracle_jtp_tests, fan_duty)
     EXPECT_EQ(nlohmann::to_string(jcmd), "{\"command\":{\"function\":\"fan_duty\",\"metadata\":{},\"parameters\":{\"index\":0,\"value\":0.12},\"tags\":[]}}");
 }
 
-TEST(miracle_jtp_tests, rwrw)
+TEST_F(MiracleJTP, rwrw)
 {
     std::filesystem::path example_path = kTestDataDir / "cmd_example.json";
     ASSERT_TRUE(std::filesystem::exists(example_path));


### PR DESCRIPTION
Makerbot Replicator+ requires that we don't mention the second extruder (b) in the jsontoolpath file. Thus we can now give the number of actual extruders to be exported to dulcificum.

Using an init method for this is not great, technically the settings list should be moved to a local variable instead of global static, and given to methods that require it. This requires a larger code change, but I would be ok with it, tell me what you think.

CURA-12313