### PR TITLE
Update tagging to add bead mode tags

### DIFF
--- a/include/dulcificum/command_types.h
+++ b/include/dulcificum/command_types.h
@@ -30,6 +30,10 @@ enum class CommandType
     Pause, // Command to allow for user defined pause.
 };
 
+#define MB_BEAD_MODE_TAG(TAG_NAME) \
+    TAG_NAME##_0, \
+    TAG_NAME##_1
+
 enum class Tag
 {
     Invalid,
@@ -43,8 +47,18 @@ enum class Tag
     Roof,
     Support,
     Sparse,
-    TravelMove
+    TravelMove,
+    MB_BEAD_MODE_TAG(Fill),
+    MB_BEAD_MODE_TAG(PrimeTower),
+    MB_BEAD_MODE_TAG(TopSurface),
+    MB_BEAD_MODE_TAG(Support),
+    MB_BEAD_MODE_TAG(SupportInterface),
+    MB_BEAD_MODE_TAG(WallOuter),
+    MB_BEAD_MODE_TAG(WallInner),
+    MB_BEAD_MODE_TAG(Skirt)
 };
+
+#undef MB_BEAD_MODE_TAG
 
 using ExtruderIndex = size_t;
 

--- a/include/dulcificum/command_types.h
+++ b/include/dulcificum/command_types.h
@@ -45,7 +45,6 @@ enum class Tag
     Restart,
     Retract,
     Roof,
-    Support,
     Sparse,
     TravelMove,
     MB_BEAD_MODE_TAG(Fill),

--- a/include/dulcificum/miracle_jtp/mgjtp_mappings_json_key_to_str.h
+++ b/include/dulcificum/miracle_jtp/mgjtp_mappings_json_key_to_str.h
@@ -26,20 +26,40 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
       { CommandType::WaitForTemperature, "wait_for_temperature" },
       { CommandType::Pause, "pause" } })
 
+#define MB_JTP_TAG(TAG_NAME, TAG_STR) \
+    { Tag::TAG_NAME, #TAG_STR }
+
+#define MB_BEAD_MODE_TAG_DEF(TAG_NAME, TAG_STR) \
+    MB_JTP_TAG(TAG_NAME##_0, TAG_STR##_0), \
+    MB_JTP_TAG(TAG_NAME##_1, TAG_STR##_1)
+
 NLOHMANN_JSON_SERIALIZE_ENUM(
     Tag,
-    { { Tag::Invalid, "Invalid" },
-      { Tag::Infill, "Infill" },
-      { Tag::Inset, "Inset" },
-      { Tag::Purge, "Purge" },
-      { Tag::QuickToggle, "Quick Toggle" },
-      { Tag::Raft, "Raft" },
-      { Tag::Restart, "Restart" },
-      { Tag::Retract, "Retract" },
-      { Tag::Roof, "Roof" },
-      { Tag::Sparse, "Sparse" },
-      { Tag::Support, "Support" },
-      { Tag::TravelMove, "Travel Move" } })
+    {
+      MB_JTP_TAG(Invalid, Invalid),
+      MB_JTP_TAG(Infill, Infill),
+      MB_JTP_TAG(Inset, Inset),
+      MB_JTP_TAG(Purge, Purge),
+      MB_JTP_TAG(QuickToggle, Quick Toggle),
+      MB_JTP_TAG(Raft, Raft),
+      MB_JTP_TAG(Restart, Restart),
+      MB_JTP_TAG(Retract, Retract),
+      MB_JTP_TAG(Roof, Roof),
+      MB_JTP_TAG(Sparse, Sparse),
+      MB_JTP_TAG(Support, Support),
+      MB_JTP_TAG(TravelMove, Travel Move),
+      MB_BEAD_MODE_TAG_DEF(Fill, FILL),
+      MB_BEAD_MODE_TAG_DEF(PrimeTower, PRIME_TOWER),
+      MB_BEAD_MODE_TAG_DEF(TopSurface, TOP_SURFACE),
+      MB_BEAD_MODE_TAG_DEF(Support, SUPPORT),
+      MB_BEAD_MODE_TAG_DEF(SupportInterface, SUPPORT_INTERFACE),
+      MB_BEAD_MODE_TAG_DEF(WallOuter, WALL_OUTER),
+      MB_BEAD_MODE_TAG_DEF(WallInner, WALL_INNER),
+      MB_BEAD_MODE_TAG_DEF(Skirt, SKIRT)
+    })
+
+#undef MB_BEAD_MODE_TAG
+#undef MB_JTP_TAG
 
 } // namespace botcmd
 

--- a/include/dulcificum/miracle_jtp/mgjtp_mappings_json_key_to_str.h
+++ b/include/dulcificum/miracle_jtp/mgjtp_mappings_json_key_to_str.h
@@ -46,7 +46,6 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
       MB_JTP_TAG(Retract, Retract),
       MB_JTP_TAG(Roof, Roof),
       MB_JTP_TAG(Sparse, Sparse),
-      MB_JTP_TAG(Support, Support),
       MB_JTP_TAG(TravelMove, Travel Move),
       MB_BEAD_MODE_TAG_DEF(Fill, FILL),
       MB_BEAD_MODE_TAG_DEF(PrimeTower, PRIME_TOWER),

--- a/src/gcode/gcode_to_command.cpp
+++ b/src/gcode/gcode_to_command.cpp
@@ -297,7 +297,6 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
 
     if (state.feature_type == "WALL-OUTER")
     {
-        move->tags.emplace_back(botcmd::Tag::Inset);
         if (state.active_tool == 0)
         {
             move->tags.emplace_back(botcmd::Tag::WallOuter_0);
@@ -307,9 +306,8 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
             move->tags.emplace_back(botcmd::Tag::WallOuter_1);
         }
     }
-    else if (state.feature_type == "INNER-OUTER")
+    else if (state.feature_type == "WALL-INNER")
     {
-        move->tags.emplace_back(botcmd::Tag::Inset);
         if (state.active_tool == 0)
         {
             move->tags.emplace_back(botcmd::Tag::WallInner_0);
@@ -321,7 +319,6 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     }
     else if (state.feature_type == "SKIN")
     {
-        move->tags.emplace_back(botcmd::Tag::Roof);
         if (state.active_tool == 0)
         {
             move->tags.emplace_back(botcmd::Tag::TopSurface_0);
@@ -333,7 +330,6 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     }
     else if (state.feature_type == "TOP-SURFACE")
     {
-        move->tags.emplace_back(botcmd::Tag::Roof);
         if (state.active_tool == 0)
         {
             move->tags.emplace_back(botcmd::Tag::TopSurface_0);
@@ -345,7 +341,6 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     }
     else if (state.feature_type == "PRIME-TOWER")
     {
-        move->tags.emplace_back(botcmd::Tag::Purge);
         if (state.active_tool == 0)
         {
             move->tags.emplace_back(botcmd::Tag::PrimeTower_0);
@@ -357,8 +352,6 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     }
     else if (state.feature_type == "FILL")
     {
-        move->tags.emplace_back(botcmd::Tag::Infill);
-        move->tags.emplace_back(botcmd::Tag::Sparse);
         if (state.active_tool == 0)
         {
             move->tags.emplace_back(botcmd::Tag::Fill_0);
@@ -374,8 +367,6 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     }
     else if (state.feature_type == "SUPPORT")
     {
-        move->tags.emplace_back(botcmd::Tag::Sparse);
-        move->tags.emplace_back(botcmd::Tag::Support);
         if (state.active_tool == 0)
         {
             move->tags.emplace_back(botcmd::Tag::Support_0);
@@ -387,7 +378,6 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     }
     else if (state.feature_type == "SUPPORT-INTERFACE")
     {
-        move->tags.emplace_back(botcmd::Tag::Support);
         if (state.active_tool == 0)
         {
             move->tags.emplace_back(botcmd::Tag::SupportInterface_0);

--- a/src/gcode/gcode_to_command.cpp
+++ b/src/gcode/gcode_to_command.cpp
@@ -275,7 +275,9 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
         }
         else
         {
+            // NOTE: A move may only have a single bead mode tag
             move->tags.emplace_back(botcmd::Tag::TravelMove);
+            return;
         }
     }
     else if (delta_e < 0)
@@ -285,28 +287,86 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     }
     else if (delta_e == 0)
     {
+        // NOTE: A move may only have a single bead mode tag
         move->tags.emplace_back(botcmd::Tag::TravelMove);
+        return;
     }
-    if (state.feature_type == "WALL-OUTER" || state.feature_type == "INNER-OUTER")
+
+    // Bead Mode Tags
+    // NOTE: A move may only have a single bead mode tag
+
+    if (state.feature_type == "WALL-OUTER")
     {
         move->tags.emplace_back(botcmd::Tag::Inset);
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::WallOuter_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::WallOuter_1);
+        }
+    }
+    else if (state.feature_type == "INNER-OUTER")
+    {
+        move->tags.emplace_back(botcmd::Tag::Inset);
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::WallInner_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::WallInner_1);
+        }
     }
     else if (state.feature_type == "SKIN")
     {
         move->tags.emplace_back(botcmd::Tag::Roof);
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::TopSurface_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::TopSurface_1);
+        }
     }
     else if (state.feature_type == "TOP-SURFACE")
     {
         move->tags.emplace_back(botcmd::Tag::Roof);
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::TopSurface_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::TopSurface_1);
+        }
     }
     else if (state.feature_type == "PRIME-TOWER")
     {
         move->tags.emplace_back(botcmd::Tag::Purge);
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::PrimeTower_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::PrimeTower_1);
+        }
     }
     else if (state.feature_type == "FILL")
     {
         move->tags.emplace_back(botcmd::Tag::Infill);
         move->tags.emplace_back(botcmd::Tag::Sparse);
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::Fill_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::Fill_1);
+        }
     }
     else if (state.feature_type == "Purge")
     {
@@ -316,10 +376,37 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     {
         move->tags.emplace_back(botcmd::Tag::Sparse);
         move->tags.emplace_back(botcmd::Tag::Support);
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::Support_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::Support_1);
+        }
     }
     else if (state.feature_type == "SUPPORT-INTERFACE")
     {
         move->tags.emplace_back(botcmd::Tag::Support);
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::SupportInterface_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::SupportInterface_1);
+        }
+    }
+    else if (state.feature_type == "SKIRT")
+    {
+        if (state.active_tool == 0)
+        {
+            move->tags.emplace_back(botcmd::Tag::Skirt_0);
+        }
+        else
+        {
+            move->tags.emplace_back(botcmd::Tag::Skirt_1);
+        }
     }
     proto_path.emplace_back(move);
 }

--- a/tests/miracle_jsontoolpath_dialect_test.cpp
+++ b/tests/miracle_jsontoolpath_dialect_test.cpp
@@ -36,12 +36,13 @@ TEST(miracle_jtp_tests, fan_duty)
     botcmd::FanDuty cmd;
     cmd.index = 0;
     cmd.duty = 0.12;
+    cmd.tags = { botcmd::Tag::TopSurface_1};
     auto jcmd = miracle_jtp::toJson(cmd);
     auto cmd1 = miracle_jtp::toCommand(jcmd);
     auto jcmd1 = miracle_jtp::toJson(*cmd1);
     EXPECT_EQ(jcmd, jcmd1);
 
-    EXPECT_EQ(nlohmann::to_string(jcmd), "{\"command\":{\"function\":\"fan_duty\",\"metadata\":{},\"parameters\":{\"index\":0,\"value\":0.12},\"tags\":[]}}");
+    EXPECT_EQ(nlohmann::to_string(jcmd), "{\"command\":{\"function\":\"fan_duty\",\"metadata\":{},\"parameters\":{\"index\":0,\"value\":0.12},\"tags\":[\"TOP_SURFACE_1\"]}}");
 }
 
 TEST(miracle_jtp_tests, rwrw)


### PR DESCRIPTION
* Add new tags to map more closely to Cura's original tagging and what's available in accel/jerk settings.
* Have specific tags per extruder so that bead mode settings can be set for them separately.
* Keep the old tags so that Cloudprint can still preview the .makerbot files...