### PR TITLE
Remove all duplicate bead mode tags

### DIFF
--- a/src/gcode/gcode_to_command.cpp
+++ b/src/gcode/gcode_to_command.cpp
@@ -270,8 +270,11 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     {
         if (delta_e > 0)
         {
+            // NOTE: A move may only have a single bead mode tag
             move->tags.emplace_back(botcmd::Tag::Restart);
             state.is_retracted = false;
+            proto_path.emplace_back(move);
+            return;
         }
         else
         {
@@ -283,8 +286,11 @@ void VisitCommand::to_proto_path(const gcode::ast::G0_G1& command)
     }
     else if (delta_e < 0)
     {
+        // NOTE: A move may only have a single bead mode tag
         move->tags.emplace_back(botcmd::Tag::Retract);
         state.is_retracted = true;
+        proto_path.emplace_back(move);
+        return;
     }
     else if (delta_e == 0)
     {


### PR DESCRIPTION
Retract and Restart are also bead mode tags, so we cannot add our custom bead mode tags on top of these tags.  (There was a firmware bug that was unintentionally blocking all tags from taking effect so we did not previously see the effects of this bug.)