### PR TITLE
Also run NPM package on PR against main branch

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,7 +34,7 @@ jobs:
 
   npm-package:
     needs: [ conan-package ]
-    if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'NP-')) }}
+    if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'NP-'))) || (github.event_name == 'pull_request' && github.head_ref == 'main') }}
     uses: ultimaker/cura-workflows/.github/workflows/npm-package.yml@main
     with:
       package_version_full: ${{ needs.conan-package.outputs.package_version_full }}


### PR DESCRIPTION
This should ensure that a PR doesn't break the NPM workflow

Contribute to NP-874