### PR TITLE
Update dependencies to allow for windows ARM build in conanfile.py

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,2 +1,2 @@
-version: "5.10.0"
+version: "5.12.0-alpha.0"
 commit_hash: "unknown"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,2 +1,2 @@
-version: "5.12.0-alpha.0"
+version: "5.11.0-alpha.0"
 commit_hash: "unknown"

--- a/conanfile.py
+++ b/conanfile.py
@@ -115,13 +115,13 @@ class DulcificumConan(ConanFile):
     def requirements(self):
         self.requires("nlohmann_json/3.11.2", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
-        self.requires("spdlog/[>=1.14.1]", transitive_headers=True)
-        self.requires("fmt/[>=11.0.2]", transitive_headers=True)
+        self.requires("spdlog/1.15.1", transitive_headers=True)
+        self.requires("fmt/11.1.3", transitive_headers=True)
         self.requires("ctre/3.7.2", transitive_headers=True)
         if self.options.with_apps:
             self.requires("docopt.cpp/0.6.3")
         if self.options.get_safe("with_python_bindings", False):
-            self.requires("cpython/3.12.2")
+            self.requires("cpython/3.12.7")
             self.requires("pybind11/2.11.1")
 
     def build_requirements(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -115,8 +115,8 @@ class DulcificumConan(ConanFile):
     def requirements(self):
         self.requires("nlohmann_json/3.11.2", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
-        self.requires("spdlog/1.15.1", transitive_headers=True)
-        self.requires("fmt/11.1.3", transitive_headers=True)
+        self.requires("spdlog/1.17.0", transitive_headers=True)
+        self.requires("fmt/12.1.0", transitive_headers=True)
         self.requires("ctre/3.7.2", transitive_headers=True)
         if self.options.with_apps:
             self.requires("docopt.cpp/0.6.3")


### PR DESCRIPTION
This pull request updates several dependencies in the `conanfile.py` to use newer versions, ensuring compatibility and benefiting from recent bug fixes and improvements.

Dependency version upgrades:

* Updated `spdlog` from a version range (`[>=1.14.1]`) to a specific newer version (`1.15.1`).
* Updated `fmt` from a version range (`[>=11.0.2]`) to a specific newer version (`11.1.3`).
* Updated `cpython` from `3.12.2` to `3.12.7` for Python bindings.


CURA-12814