### PR TITLE
add detailed logging and exception handling to GCode parser

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,2 +1,2 @@
-version: "5.10.1"
+version: "5.10.2"
 commit_hash: "unknown"

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class DulcificumConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "enable_extensive_warnings": False,
+        "enable_extensive_warnings": True,
         "with_apps": False,
         "with_python_bindings": True,
     }

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,6 +10,7 @@ from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
 from conan.tools.scm import Version, Git
 from conan.errors import ConanException
 
+
 required_conan_version = ">=2.7.0"
 
 class DulcificumConan(ConanFile):

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class DulcificumConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "enable_extensive_warnings": True,
+        "enable_extensive_warnings": False,
         "with_apps": False,
         "with_python_bindings": True,
     }

--- a/src/gcode/ast/entries.cpp
+++ b/src/gcode/ast/entries.cpp
@@ -55,7 +55,7 @@ G0_G1::G0_G1(size_t line_index, const std::string& raw_line, regex_result_t capt
     // clang-format on
     if (X == std::nullopt && Y == std::nullopt && Z == std::nullopt && E == std::nullopt && F == std::nullopt)
     {
-        throw std::runtime_error(fmt::format("Unable to parse: [{}] {}", line_index, raw_line));
+        spdlog::warn("Unable to parse: [{}] {}", line_index, raw_line);
     }
 }
 

--- a/src/gcode/parse.cpp
+++ b/src/gcode/parse.cpp
@@ -14,38 +14,28 @@ namespace dulcificum::gcode
 
 gcode::ast::ast_t parse(std::string_view content)
 {
-    spdlog::info("Parsing GCode as AST test");
-    try {
-        spdlog::info("Creating string stream from content");
-        std::istringstream stream(content.data());
-        std::string line;
-        gcode::ast::ast_t ast;
-        size_t index{ 1 };
-        spdlog::info("Starting line parsing loop");
-        while (std::getline(stream, line))
+    spdlog::info("Parsing GCode as AST");
+    std::istringstream stream(content.data());
+    std::string line;
+    gcode::ast::ast_t ast;
+
+    size_t index{ 1 };
+    while (std::getline(stream, line))
+    {
+        if (line == "G1" || line == "G0")
         {
-            spdlog::info("Parsing line {}", index);
-            std::optional<ast::node_t> node;
-            try {
-                node = gcode::ast::factory(index, line);
-                spdlog::info("Factory returned node: {}", node.has_value());
-            } catch (const std::exception& e) {
-                spdlog::info("Exception in factory for index {}: {}", index, e.what());
-                throw;
-            }
+            spdlog::info("Skipping empty line with command {}", line);
             ++index;
-            if (node)
-            {
-                spdlog::info("Emplacing node at AST index: {}", index - 1);
-                ast.emplace_back(*node);
-            }
+            continue;
         }
-        spdlog::info("Finished parsing, returning AST");
-        return ast;
-    } catch (const std::exception& e) {
-        spdlog::info("Exception in parse(): {}", e.what());
-        throw;
+        std::optional<ast::node_t> node = gcode::ast::factory(index++, line);
+        if (node)
+        {
+            ast.emplace_back(*node);
+        }
     }
+
+    return ast;
 }
 
 } // namespace dulcificum::gcode

--- a/src/gcode/parse.cpp
+++ b/src/gcode/parse.cpp
@@ -14,22 +14,38 @@ namespace dulcificum::gcode
 
 gcode::ast::ast_t parse(std::string_view content)
 {
-    spdlog::info("Parsing GCode as AST");
-    std::istringstream stream(content.data());
-    std::string line;
-    gcode::ast::ast_t ast;
-
-    size_t index{ 1 };
-    while (std::getline(stream, line))
-    {
-        std::optional<ast::node_t> node = gcode::ast::factory(index++, line);
-        if (node)
+    spdlog::info("Parsing GCode as AST test");
+    try {
+        spdlog::info("Creating string stream from content");
+        std::istringstream stream(content.data());
+        std::string line;
+        gcode::ast::ast_t ast;
+        size_t index{ 1 };
+        spdlog::info("Starting line parsing loop");
+        while (std::getline(stream, line))
         {
-            ast.emplace_back(*node);
+            spdlog::info("Parsing line {}", index);
+            std::optional<ast::node_t> node;
+            try {
+                node = gcode::ast::factory(index, line);
+                spdlog::info("Factory returned node: {}", node.has_value());
+            } catch (const std::exception& e) {
+                spdlog::info("Exception in factory for index {}: {}", index, e.what());
+                throw;
+            }
+            ++index;
+            if (node)
+            {
+                spdlog::info("Emplacing node at AST index: {}", index - 1);
+                ast.emplace_back(*node);
+            }
         }
+        spdlog::info("Finished parsing, returning AST");
+        return ast;
+    } catch (const std::exception& e) {
+        spdlog::info("Exception in parse(): {}", e.what());
+        throw;
     }
-
-    return ast;
 }
 
 } // namespace dulcificum::gcode


### PR DESCRIPTION
Noticed an extra "G1" command in the Gcode causing the parsing of gcode to toolpath failure, just added an extra condition to ignore it. Needs proper solving in Curaengine. 

NP-1297